### PR TITLE
skf/skf.py: close file correctly in log function

### DIFF
--- a/skf/skf.py
+++ b/skf/skf.py
@@ -83,7 +83,7 @@ def log(message, value, threat):
         # If not exists, create the file
         file = open('logs/'+dateLog+'.txt', 'w+')
     file.write(dateTime +' '+ message +' ' + ' ' + value + ' ' + threat + ' ' +ip + "\r\n")
-    file.close  
+    file.close()
 
 def blockUsers():
     """Check the log file and based on the FAIL items block a user"""


### PR DESCRIPTION
`file.close` is the attribute of the `file` variable. It needs the ending parens to really call the function.