### PR TITLE
AWS cloudformation

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,12 @@ The final step:
 The application can be visited at port http://the_ip_/:5443
 Also now you can apply your favourite Apache SSL/TLS settings.
 
+#### AWS installation
+
+A CloudFormation template is provided to make it easy to set up the
+Security Knowledge Framework in AWS. For more information consult
+[the README in the `cloudformation` directory](cloudformation/README.md).
+
 ##<a name="usage"></a>Usage
 
 For more detailed information such as user guides and other documentation see:

--- a/cloudformation/README.md
+++ b/cloudformation/README.md
@@ -1,4 +1,4 @@
-Security Knowldge Framework - AWS
+Security Knowledge Framework - AWS
 =================================
 
 This will allow you to run the OWASP Security Knowledge Framework in
@@ -17,7 +17,7 @@ in AWS**.
 If you're experienced with AWS then the steps are as follows:
 
 1. create SSL cert and upload to your AWS account
-2. convert the provided yaml file to JSON
+2. convert the provided YAML file to JSON
 3. create a new CloudFormation stack from the JSON file
 4. CNAME your domain to the `LoadBalancerUrl` in the stack's `Outputs`
 
@@ -26,8 +26,9 @@ Further details on each step are below.
 ### 1. Create an SSL certificate for the Security Knowledge Framework
 
 You will need an SSL certificate before you can set the SKF up in
-AWS. If you already have a wildcard certificate you will be able to
-use that, otherwise you'll need to do the following:
+AWS. If you already have an appropriate certificate in your account
+(perhaps you've already set it up or you have a wildcard) you will be
+able to use that, otherwise you'll need to do the following:
 
 1. create/purchase an SSL certificate
 2. use the AWS CLI tool to upload it to AWS
@@ -36,17 +37,15 @@ How you accomplish the first point will depend on you / your company's
 preferences. To upload the certificate to your AWS account you can
 [follow AWS' instructions for uploading a new certificate](http://docs.aws.amazon.com/ElasticLoadBalancing/latest/DeveloperGuide/ssl-server-cert.html#upload-cert).
 The "Uploading the Server Certificate" section is the bit you're
-after.
+after. The output of this command will give you the new certificate's
+ARN (Amazon Resource Name). Make a note of it because you'll need it
+in a moment.
 
-The output of this command will give you the new certificate's ARN
-(Amazon Resource Name). Make a note of it because you'll need it in a
-moment.
+### 2. Convert to JSON
 
-### 2. Convert to Json
-
-The accompanying cloudformation template is in `yaml` format for
+The accompanying CloudFormation template is in `YAML` format for
 clarity but AWS expects CloudFormation templates to be in JSON
-format. You must first convert the file using any `yaml` -> `json`
+format. You must first convert the file using any `YAML` -> `JSON`
 tool (many online tools exist or you can use a library in your
 favourite language).
 
@@ -70,7 +69,7 @@ top right of the console.
 Click the `Create Stack` button to create a new stack using
 CloudFormation.
 
-On the `Select Template` screen, chosoe the JSON file you created in
+On the `Select Template` screen, choose the JSON file you created in
 the previous step and click `Next`.
 
 Next you'll see the `Specify Details` screen. This is where you
@@ -84,11 +83,11 @@ you.
 
 #### Parameters
 
-The parameters control the way the cloudformation works.
+The following parameters are required for the CloudFormation.
 
 ##### DataBucketName
 
-This stack will require an S3 bucket to persist the Security Knowledge
+This stack will create an S3 bucket to persist the Security Knowledge
 Framework's database. This means that if the EC2 instance dies another
 one will appear in its place a few moments later and no-one will even
 notice that it died.
@@ -99,11 +98,12 @@ specific to you, for example
 
 ##### HttpsAccessCidr
 
-This allows you to lock down access to the SKF. If your office has an
-IP rangeyou can put that in here. If you'd like to lock it down to a
-single IP address then you can do that by specifying a single IP as
-the range e.g. `10.11.12.13/32`. If you want to allow access from
-anywhere in the world you can put an open range there `0.0.0.0/0`.
+This allows you to lock down access to the SKF. If you have an IP
+range you can put that in here (e.g. for an office). If you'd like to
+lock it down to a single IP address then you can do that by specifying
+a single IP as the range e.g. `10.11.12.13/32`. If you want to allow
+access from anywhere in the world you can allow any traffic using
+`0.0.0.0/0`.
 
 ##### KeyName
 
@@ -147,8 +147,8 @@ free to ignore both and click `Next`.
 #### Review
 
 This last step is to confirm everything before the stack gets
-created. If everything looks OK then select the confirmation checkbox
-and click `Create`.
+created. If it all looks OK then select the confirmation checkbox and
+click `Create`.
 
 #### Creation
 
@@ -163,9 +163,9 @@ see `LoadBalancerUrl`. Make a note of this for the next step.
 
 ### 4. DNS
 
-The last stepo is to point the domain you'd like to use at the new
+The last step is to point the domain you'd like to use at the new
 stack. You can do this by creating a CNAME record that points to the
 `LoadBalancerUrl` we saw above. To look up the `LoadBalancerUrl` go to
 the CloudFormation section of the AWS console, choose the stack you
-created for the secuerity knowledge framework and look at the
+created for the security knowledge framework and look at the
 `Outputs` tab.

--- a/cloudformation/README.md
+++ b/cloudformation/README.md
@@ -1,0 +1,171 @@
+Security Knowldge Framework - AWS
+=================================
+
+This will allow you to run the OWASP Security Knowledge Framework in
+AWS by using a
+[CloudFormation template](https://aws.amazon.com/cloudformation/) to
+create all the required resources automatically.
+
+This guide assumes you have an AWS account and some experience using
+AWS.
+
+**Please be aware that following these steps will incur ongoing costs
+in AWS**.
+
+## Usage
+
+If you're experienced with AWS then the steps are as follows:
+
+1. create SSL cert and upload to your AWS account
+2. convert the provided yaml file to JSON
+3. create a new CloudFormation stack from the JSON file
+4. CNAME your domain to the `LoadBalancerUrl` in the stack's `Outputs`
+
+Further details on each step are below.
+
+### 1. Create an SSL certificate for the Security Knowledge Framework
+
+You will need an SSL certificate before you can set the SKF up in
+AWS. If you already have a wildcard certificate you will be able to
+use that, otherwise you'll need to do the following:
+
+1. create/purchase an SSL certificate
+2. use the AWS CLI tool to upload it to AWS
+
+How you accomplish the first point will depend on you / your company's
+preferences. To upload the certificate to your AWS account you can
+[follow AWS' instructions for uploading a new certificate](http://docs.aws.amazon.com/ElasticLoadBalancing/latest/DeveloperGuide/ssl-server-cert.html#upload-cert).
+The "Uploading the Server Certificate" section is the bit you're
+after.
+
+The output of this command will give you the new certificate's ARN
+(Amazon Resource Name). Make a note of it because you'll need it in a
+moment.
+
+### 2. Convert to Json
+
+The accompanying cloudformation template is in `yaml` format for
+clarity but AWS expects CloudFormation templates to be in JSON
+format. You must first convert the file using any `yaml` -> `json`
+tool (many online tools exist or you can use a library in your
+favourite language).
+
+### 3. CloudFormation
+
+Log into the AWS console using your IAM username and password. Make
+sure your user has full admin access because CloudFormation will
+require lots of permissions.
+
+Once you have logged in, go to the 'CloudFormation' section of the
+console.
+
+Make sure you are in the correct region, using the drop down in the
+top right of the console.
+
+> *Note* You will need a VPC to run the SKF. If your AWS account was
+> created after December 2013 you will have a "default VPC"
+> available. If not, or if you have deleted the default VPC make sure
+> you first set up a VPC in the region you want to use the SKF.
+
+Click the `Create Stack` button to create a new stack using
+CloudFormation.
+
+On the `Select Template` screen, chosoe the JSON file you created in
+the previous step and click `Next`.
+
+Next you'll see the `Specify Details` screen. This is where you
+configure the Security Knowledge Framework for your needs.
+
+#### Stack name
+
+This is the name to give to this AWS stack. Something like
+`security-knowledge-framework` is simple, but whatever makes sense to
+you.
+
+#### Parameters
+
+The parameters control the way the cloudformation works.
+
+##### DataBucketName
+
+This stack will require an S3 bucket to persist the Security Knowledge
+Framework's database. This means that if the EC2 instance dies another
+one will appear in its place a few moments later and no-one will even
+notice that it died.
+
+S3 bucket names must be globally unique so choose something that's
+specific to you, for example
+`company-name-security-knowledge-framework`
+
+##### HttpsAccessCidr
+
+This allows you to lock down access to the SKF. If your office has an
+IP rangeyou can put that in here. If you'd like to lock it down to a
+single IP address then you can do that by specifying a single IP as
+the range e.g. `10.11.12.13/32`. If you want to allow access from
+anywhere in the world you can put an open range there `0.0.0.0/0`.
+
+##### KeyName
+
+The EC2 instance that runs the SKF will need an ssh key, specified by
+name. The field will auto-complete with available key names.
+
+This key can be used to ssh into the box if required. If you need
+access choose (or create) a key that you have access to. If you don't
+want to ssh into the box then just create an ssh key and discard the
+private key.
+
+##### SSHAccessCidr
+
+This is the IP range that you would like to allow ssh connections
+from. You can specify an IP range, a single IP (with `v.x.y.z/32`) or
+leave it completely open (NOT RECOMMENDED) with `0.0.0.0/0`.
+
+##### SSLCertificateArn
+
+This is the ARN of the SSL certificate to use. If you set it up
+earlier you'll have the ARN to hand, if not you can run the
+`list-server-certificates` CLI command to see the available
+certificates.
+
+##### Subnets
+
+Choose the subnet or subnets that the SKF should run in. This will
+autocomplete from the available subnets.
+
+##### VpcId
+
+The VPC that the SKF should run in. Generally you'll only have one
+available. If you have multiple VPCs make sure you choose the right
+one and ensure it matches the choice of subnets.
+
+#### Options
+
+Here you may add tags to the stack and setup advanced options. Feel
+free to ignore both and click `Next`.
+
+#### Review
+
+This last step is to confirm everything before the stack gets
+created. If everything looks OK then select the confirmation checkbox
+and click `Create`.
+
+#### Creation
+
+AWS will go ahead and create all the components necessary for running
+the SKF. This includes Load Balancers, an AutoscalingGroup, all the
+required AWS Permissions and Security Groups, the S3 bucket that will
+persist the database and of course, the EC2 instance that will run the
+SKF.
+
+When it completes look at the `Outputs` tab of that stack and you will
+see `LoadBalancerUrl`. Make a note of this for the next step.
+
+### 4. DNS
+
+The last stepo is to point the domain you'd like to use at the new
+stack. You can do this by creating a CNAME record that points to the
+`LoadBalancerUrl` we saw above. To look up the `LoadBalancerUrl` go to
+the CloudFormation section of the AWS console, choose the stack you
+created for the secuerity knowledge framework and look at the
+`Outputs` tab.

--- a/cloudformation/owasp-security-knowledge-framework.template.yaml
+++ b/cloudformation/owasp-security-knowledge-framework.template.yaml
@@ -1,0 +1,286 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: Sets up a running instance of the OWASP Security Knowledge Framework
+
+Parameters:
+  Subnets:
+    Description: The subnets where the OWASP SKF will run
+    Type: List<AWS::EC2::Subnet::Id>
+  VpcId:
+    Description: The VPC in which the OWASP SKF will run
+    Type: AWS::EC2::VPC::Id
+  KeyName:
+    Description: An ssh keypair to put on the OWASP SKF instance
+    Type: AWS::EC2::KeyPair::KeyName
+  HttpsAccessCidr:
+    Description: A CIDR from which https access to the OWASP SKF's load balancers is allowed
+    Type: String
+    AllowedPattern: ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}/[0-9]{1,2}$
+    ConstraintDescription: Parameter should be a CIDR block e.g. "1.2.3.4/32"
+  SSHAccessCidr:
+    Description: A CIDR from which SSH access to the OWASP SKF instance is allowed
+    Type: String
+    AllowedPattern: ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}/[0-9]{1,2}$
+    ConstraintDescription: Parameter should be a CIDR block e.g. "1.2.3.4/32"
+  SSLCertificateArn:
+    Description: ARN of SSL certifcate the ELBs should use
+    Type: String
+  DataBucketName:
+    Description: Name to use for the S3 bucket that persists the database
+    Type: String
+
+Mappings:
+  Constants:
+    App:
+      Value: security-knowledge-framework
+
+Resources:
+  DataBucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      AccessControl: Private
+      BucketName:
+        Ref: DataBucketName
+
+  LoadBalancerSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: HTTPS access to the load balancer from the CIDR block
+      VpcId:
+        Ref: VpcId
+      SecurityGroupIngress:
+      - IpProtocol: tcp
+        FromPort: 443
+        ToPort: 443
+        CidrIp:
+          Ref: HttpsAccessCidr
+      Tags:
+      - Key: App
+        Value:
+          Fn::FindInMap: [ Constants, App, Value ]
+
+  InstanceSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: SKF EC2 instance
+      VpcId:
+        Ref: VpcId
+      SecurityGroupIngress:
+      # allow ELB to talk to instance
+      - IpProtocol: tcp
+        FromPort: 8001
+        ToPort: 8001
+        SourceSecurityGroupId:
+          Ref: LoadBalancerSecurityGroup
+      # allow SSH access to specified IP range
+      - IpProtocol: tcp
+        FromPort: 22
+        ToPort: 22
+        CidrIp:
+          Ref: SSHAccessCidr
+      SecurityGroupEgress:
+      # allow instance to make http requests
+      - IpProtocol: tcp
+        FromPort: 80
+        ToPort: 80
+        CidrIp: 0.0.0.0/0
+      - IpProtocol: tcp
+        FromPort: 443
+        ToPort: 443
+        CidrIp: 0.0.0.0/0
+      Tags:
+      - Key: App
+        Value:
+          Fn::FindInMap: [ Constants, App, Value ]
+
+  InstanceRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+        - Effect: Allow
+          Principal:
+            Service:
+            - ec2.amazonaws.com
+          Action:
+          - sts:AssumeRole
+      Path: /
+      Policies:
+      - PolicyName: skf-instance-policy
+        PolicyDocument:
+          Statement:
+          # grant access to the S3 bucket that backs up the database
+          - Effect: Allow
+            Resource:
+              Fn::Join:
+              - ""
+              - - "arn:aws:s3"
+                - ":::"
+                - Ref: DataBucketName
+            Action:
+            - s3:ListBucket
+          - Effect: Allow
+            Resource:
+              Fn::Join:
+              - ""
+              - - "arn:aws:s3"
+                - ":::"
+                - Ref: DataBucketName
+                - /*
+            Action:
+            - s3:GetObject
+            - s3:PutObject
+            - s3:PutObjectAcl
+
+  InstanceProfile:
+    Type: AWS::IAM::InstanceProfile
+    Properties:
+      Path: /
+      Roles:
+      - Ref: InstanceRole
+
+  LoadBalancer:
+    Type: AWS::ElasticLoadBalancing::LoadBalancer
+    Properties:
+      Listeners:
+      - LoadBalancerPort: 443
+        Protocol: HTTPS
+        SSLCertificateId:
+          Ref: SSLCertificateArn
+        InstanceProtocol: HTTP
+        InstancePort: 8001
+      CrossZone: true
+      HealthCheck:
+        Target: HTTP:8001/
+        HealthyThreshold: 2
+        UnhealthyThreshold: 10
+        Interval: 30
+        Timeout: 10
+      Subnets:
+        Ref: Subnets
+      SecurityGroups:
+      - Ref: LoadBalancerSecurityGroup
+      Tags:
+      - Key: App
+        Value:
+          Fn::FindInMap: [ Constants, App, Value ]
+
+  LaunchConfig:
+    Type: AWS::AutoScaling::LaunchConfiguration
+    Properties:
+      KeyName:
+        Ref: KeyName
+      ImageId: ami-47a23a30
+      SecurityGroups:
+      - Ref: InstanceSecurityGroup
+      InstanceType: t2.nano
+      IamInstanceProfile:
+        Ref: InstanceProfile
+      AssociatePublicIpAddress: true
+      UserData:
+        Fn::Base64:
+          Fn::Join:
+          - ""
+          - - |
+              #!/bin/bash -ev
+            - s3bucket=
+            - Ref: DataBucketName
+            - |
+
+              # install dependencies
+              locale-gen en_GB.UTF-8
+              apt-get --yes update
+              apt-get install --yes git apache2 libapache2-mod-wsgi sqlite3 lib32z1-dev python-dev libxml2-dev libxslt-dev libffi-dev libssl-dev python-pip
+              a2enmod wsgi
+              pip install awscli https://github.com/mitsuhiko/flask/tarball/master owasp-skf
+
+              # setup skf
+              mkdir /owaspskf
+              cd /owaspskf
+              git clone https://github.com/blabla1337/skf-flask.git
+              cd skf-flask/skf
+
+              # remove adhoc SSL
+              sed -i "s/, ssl_context='adhoc'//" skf.py
+
+              # fetch db from persistent storage
+              aws s3 cp s3://$s3bucket/owaspskf/skf.db skf.db || true
+
+              # application wsgi file
+              cat <<SKF_APP_WSGI > skf.wsgi
+              import sys, os
+              sys.path.insert (0,'/owaspskf/skf-flask/skf')
+              os.chdir("/owaspskf/skf-flask/skf")
+              from skf import app as application
+              SKF_APP_WSGI
+
+              # apache config
+              cd /etc/apache2/sites-available/
+
+              cat <<SKF_APACHE_CONF > skf.conf
+              WSGIRestrictStdout Off
+              Listen 8001
+              <VirtualHost *:8001>
+
+                  WSGIDaemonProcess skf user=www-data group=www-data threads=5
+                  WSGIScriptAlias / /owaspskf/skf-flask/skf/skf.wsgi
+
+                  <Directory /owaspskf/skf-flask/skf>
+                      WSGIProcessGroup skf
+                      WSGIApplicationGroup %{GLOBAL}
+                      Order deny,allow
+                      Allow from all
+                      Require all granted
+                  </Directory>
+
+              </VirtualHost>
+              SKF_APACHE_CONF
+
+              a2dissite 000-default.conf
+              a2ensite skf.conf
+
+              # fix perms
+              chmod +x /owaspskf/skf-flask/skf/skf.py
+              chown -R www-data:www-data /owaspskf/skf-flask
+
+              # restart apache
+              sudo service apache2 restart
+
+              # schedule regular sync of the sqlite database
+              touch /owaspskf/cron-lastrun.log
+              chown www-data /owaspskf/cron-lastrun.log
+              cat <<SKF_CRON > /etc/cron.d/skf
+              */5 * * * *  www-data  /usr/local/bin/aws s3 cp /owaspskf/skf-flask/skf/skf.db s3://$s3bucket/owaspskf/skf.db > /owaspskf/cron-lastrun.log 2>&1
+              SKF_CRON
+
+  AutoscalingGroup:
+    Type: AWS::AutoScaling::AutoScalingGroup
+    Properties:
+      AvailabilityZones:
+        Fn::GetAZs: ""
+      VPCZoneIdentifier:
+        Ref: Subnets
+      LaunchConfigurationName:
+        Ref: LaunchConfig
+      MinSize: 0
+      MaxSize: 1
+      DesiredCapacity: 1
+      HealthCheckType: ELB
+      HealthCheckGracePeriod: 120
+      LoadBalancerNames:
+      - Ref: LoadBalancer
+      Tags:
+      - Key: Name
+        Value:
+          Fn::FindInMap: [ Constants, App, Value ]
+        PropagateAtLaunch: true
+      - Key: App
+        Value:
+          Fn::FindInMap: [ Constants, App, Value ]
+        PropagateAtLaunch: true
+
+Outputs:
+  LoadBalancerUrl:
+    Value:
+      'Fn::GetAtt':
+      - LoadBalancer
+      - DNSName


### PR DESCRIPTION
This commit adds a CloudFormation template that can be used to automatically create all the infrastructure AWS requires to run the SKF. A developer just needs to add their own DNS and certificate to have a configured installation of the SKF.

The commit also adds instructions for using this template and makes mention of it in the main README.
