### PR TITLE
Enable filters for coding languages on code examples

### DIFF
--- a/Angular/src/app/app.module.ts
+++ b/Angular/src/app/app.module.ts
@@ -56,6 +56,7 @@ import { UserManageComponent } from './user-manage/user-manage.component';
 import { StartsWithPipe } from './pipes/starts-with.pipe';
 import { OrderBy } from './pipes/order-by.pipe';
 import { StringFilterPipe } from './pipes/string-filter.pipe';
+import { LangFilterPipe } from './pipes/lang-filter.pipe';
 
 import { HighlightJsModule, HighlightJsService } from 'angular2-highlight-js';
 import { FirstLoginComponent } from './first-login/first-login.component';
@@ -89,6 +90,7 @@ import { NgSelectModule } from '@ng-select/ng-select';
     StartsWithPipe,
     OrderBy,
     StringFilterPipe,
+    LangFilterPipe,
     FirstLoginComponent,
     UndefinedComponent,
     LabsComponent,

--- a/Angular/src/app/code-examples/code-examples.component.html
+++ b/Angular/src/app/code-examples/code-examples.component.html
@@ -1,7 +1,8 @@
-<!-- 
-    Security Knowledge Framework is an expert system application 
+<!--
+    Security Knowledge Framework is an expert system application
     that uses OWASP Application Security Verification Standard, code examples,
-    helps developers in pre-development and post-development.  
+
+    helps developers in pre-development and post-development.
     Copyright (C) 2020  Glenn ten Cate, Riccardo ten Cate
 
     This program is free software: you can redistribute it and/or modify
@@ -44,6 +45,11 @@
 					placeholder="Search vulnerability" />
 				<i class="fa fa-search"></i>
 			</div>
+			<div class="col-md-2">
+                <ng-select id="selectLang" [items]="codeLangs" [(ngModel)]="queryLang" bindLabel="codeLangs" placeholder="Select tags"
+                  appendTo="body" multiple="true">
+                </ng-select>
+            </div>
 		</div>
 		<div *ngIf="category_id" class="content-panel narrow" style="width:100%">
 			<div *ngIf="isSubmitted && formControls.title.errors" class="help-block">
@@ -71,13 +77,13 @@
 			<div class="row">
 				<div (click)="highlight()" class="col-lg-12">
 					<ngb-accordion [closeOthers]="true" #acc="ngbAccordion">
-						<div *ngFor="let examples of codeExamples | stringFilter : queryString">
+						<div *ngFor="let examples of codeExamples | stringFilter : queryString | langFilter : queryLang ">
 							<br />
 							<ngb-panel title="{{examples.title}}: {{examples.code_lang}}">
 								<ng-template ngbPanelContent>
 									<pre><code id="changeme" class="php">
-							 {{examples.content}} 
-			
+							 {{examples.content}}
+
 							</code></pre>
 									<button (click)="deleteCodeModal(deleteCode)"
 										style="float:right; margin-left:1%; margin-bottom:1%; margin-right:1%"

--- a/Angular/src/app/code-examples/code-examples.component.ts
+++ b/Angular/src/app/code-examples/code-examples.component.ts
@@ -22,12 +22,13 @@ export class CodeExamplesComponent implements OnInit {
   public codeExamples: CodeExample[] = [];
   public hljs;
   public queryString;
+  public codeLangs;
   codeForm: FormGroup;
   public isSubmitted: boolean;
   public delete: string;
   public category_id: number;
   public categories: Category[];
-  
+
   constructor(private codeService: CodeExamplesService, private categoryService: CategoryService, private highlightJsService: HighlightJsService, private el: ElementRef, private modalService: NgbModal, private formBuilder: FormBuilder) {
     this.lang = localStorage.getItem('code_lang')
   }
@@ -57,7 +58,10 @@ export class CodeExamplesComponent implements OnInit {
   getCodeExamples(category_id: number) {
     this.codeService.getCode(this.category_id)
       .subscribe(examples => {
-        this.codeExamples = examples
+        this.codeExamples = examples;
+        let codeLangSet = new Set();
+        this.codeExamples.map(item => codeLangSet.add(item.code_lang));
+        this.codeLangs = Array.from(codeLangSet);
       },
         () => console.log('There was an error catching code examples.'))
   }

--- a/Angular/src/app/pipes/lang-filter.pipe.ts
+++ b/Angular/src/app/pipes/lang-filter.pipe.ts
@@ -1,0 +1,18 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({
+  name: 'langFilter',
+  pure: false
+})
+export class LangFilterPipe implements PipeTransform {
+
+  transform(items: any[], args: any[]): any {
+    if (args && args.length > 0) {
+      return items.filter(item => args.indexOf(item.code_lang) >= 0);
+    }
+    else {
+      return items;
+    }
+  }
+
+}

--- a/Angular/src/styles.css
+++ b/Angular/src/styles.css
@@ -1,6 +1,18 @@
 /* You can add global styles to this file, and also import other style files */
 @import "~@ng-select/ng-select/themes/default.theme.css";
 
+.ng-select .ng-select-container {
+  min-height: 50px;
+}
+
+.ng-select.ng-select-single .ng-select-container {
+  height: 50px;
+}
+
+.ng-placeholder {
+  margin-top: 10px;
+}
+
 .ng-dropdown-panel .ng-dropdown-panel-items .ng-option.ng-option-selected {
   background: #515594;
   color: #ffffff;


### PR DESCRIPTION
Fixes #557 

I have added a search to enable the filter on coding languages in Code examples.

Now it looks like

![image](https://user-images.githubusercontent.com/16623935/74090054-5e5b1500-4acd-11ea-86c2-4ae590c746cf.png)

It also supports multiple language selection

![image](https://user-images.githubusercontent.com/16623935/74090065-92ced100-4acd-11ea-9469-ac9c4a597755.png)
