### PR TITLE
Add option to run angular with fast configuration

### DIFF
--- a/Angular/angular.json
+++ b/Angular/angular.json
@@ -25,7 +25,7 @@
             ],
             "scripts": [
               "node_modules/prismjs/prism.js",
-              "node_modules/prismjs/components/prism-csharp.min.js", 
+              "node_modules/prismjs/components/prism-csharp.min.js",
               "node_modules/prismjs/components/prism-css.min.js",
               "node_modules/prismjs/plugins/line-numbers/prism-line-numbers.js"
             ]
@@ -47,6 +47,22 @@
                   "with": "src/environments/environment.prod.ts"
                 }
               ]
+            },
+            "development": {
+              "optimization": false,
+              "sourceMap": false,
+              "extractCss": true,
+              "namedChunks": false,
+              "aot": false,
+              "extractLicenses": true,
+              "vendorChunk": false,
+              "buildOptimizer": false,
+              "fileReplacements": [
+                {
+                  "replace": "src/environments/environment.ts",
+                  "with": "src/environments/environment.prod.ts"
+                }
+              ]
             }
           }
         },
@@ -58,6 +74,9 @@
           "configurations": {
             "production": {
               "browserTarget": "skf-angular:build:production"
+            },
+            "development": {
+              "browserTarget": "skf-angular:build:development"
             }
           }
         },

--- a/installations/local/skf-angular.sh
+++ b/installations/local/skf-angular.sh
@@ -2,4 +2,5 @@
 
 # Start the SKF Angular app
 cd ../../Angular
-ng serve --configuration=production --public-host localhost:443
+configuration=${1:-production}
+ng serve --configuration=$configuration --public-host localhost:443


### PR DESCRIPTION
I've added an option to run `skf-angular.sh` in `development` mode. For this, I've added a new configuration in `angular.json` named `development`, with different build options. I did this because rebuilding was extremely slow.

After this PR is merged there were will be following changes:

if someone runs: `./skf-angular.sh` then it will start the server under `production` configuration(rebuilding would be slow)
if someone runs: `./skf-angular.sh development` it will start the server under `development` configuration(rebuilding would be fast).