### PR TITLE
Fix platform issues on new OS.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
 
   mysql:
     container_name: skf-mysql_container
+    platform: linux/x86_64
     image: blabla1337/mysql
     restart: always
     environment:
@@ -35,6 +36,7 @@ services:
 
   skf-angular:
     container_name: skf-angular_container
+    platform: linux/x86_64
     depends_on:
       - "rabbitmq"
       - "nginx"
@@ -47,6 +49,7 @@ services:
 
   skf-api:
     container_name: skf-api_container
+    platform: linux/x86_64
     depends_on:
       - "rabbitmq"
       - "nginx"


### PR DESCRIPTION
This PR aims to solve issue #736 .
I think blabla1337/mysql and other image are not available for new docker versions in linux/arm64/v8 (bydefault).
So i have specified platform for every blabla1337 image in docker compose i.e linux/arm64.

This fixed my issue.
<img width="1440" alt="Screenshot 2021-03-14 at 12 29 36 PM" src="https://user-images.githubusercontent.com/44541855/111060410-a7487e80-84c2-11eb-9d0e-c2d1e6368028.png">

Please review it @blabla1337 .