### PR TITLE
Bump skf-api version to 4.0.6 in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,7 +56,7 @@ services:
     restart: always
     volumes:
       - ~/.kube/config:/home/user_api/.kube/config
-    image: "blabla1337/skf-api:4.0.4"
+    image: "blabla1337/skf-api:4.0.6"
     environment:
       - SKF_FLASK_DEBUG=False
       - SKF_API_URL=http://localhost/api


### PR DESCRIPTION
Current setting points to skf-api:4.0.4 which don't reflect commit https://github.com/blabla1337/skf-flask/commit/27e48ac983809eca2403eff98396e7f11b4cdafe and thus links to the writeups in the old format are broken.
Current behavior with skf-api:4.0.4:
Links in DB are in the old format
![image](https://user-images.githubusercontent.com/17573662/166842747-982a785f-888d-4f19-8e25-21dbfb92de3c.png)

This comes from the initial_data.py:
![image](https://user-images.githubusercontent.com/17573662/166842867-34c8fbb7-e5a0-4f9a-8ad4-98f3bc88f3b1.png)

skf-api:4.0.6 solves this.
