### PR TITLE
fixed the clearing of localstorage when skiplogin

### DIFF
--- a/Angular2/src/app/app.component.ts
+++ b/Angular2/src/app/app.component.ts
@@ -27,9 +27,11 @@ export class AppComponent implements OnInit {
   ngOnInit() {
     setTimeout(() =>
     {
-      localStorage.setItem('session', 'expired');
-      localStorage.clear();
-      location.replace('/auth/login');
+      if(this.loginProvider == "skiploginprovider"){
+        localStorage.setItem('session', 'expired');
+        localStorage.removeItem("")
+        location.replace('/auth/login');
+      }
     }, 7100000);
   }
 }


### PR DESCRIPTION
prevent automatic logout when in the "skiploginprovider" to clear all the local storage items.
This would normally break functionality in the app such as showing checklist results