### PR TITLE
Fix typo on Minikube.md

### DIFF
--- a/installations/docker/Minikube.md
+++ b/installations/docker/Minikube.md
@@ -24,7 +24,7 @@ Then we need to change the docker-compose.yaml file.
 First we need to get the base64 encode of the ~./kube/config file:
 
 ```
-cat ~./kube/config | base64 | tr -d '\n'
+cat ~/.kube/config | base64 | tr -d '\n'
 ```
 
 Copy the output of the above command and set it as value for the ```LABS_KUBE_CONF``` variable:


### PR DESCRIPTION
Why:

* There's a minor typo in the file path

This change addresses the need by:

*  Changing the path so we can correctly access the Kubernetes configuration files located in the user's home directory under the ".kube" directory.